### PR TITLE
Allow to debug python tests

### DIFF
--- a/fbtest.py
+++ b/fbtest.py
@@ -1013,12 +1013,15 @@ class TestVersion(object):
                     sys.stderr = StringIO()
                     # put Python code into temporary file to allow easy debugging
                     test_src = substitute_macros(self.test_script)
-                    temp_src_file = tempfile.NamedTemporaryFile(dir=context.environment['temp_directory'], delete=False, suffix='.py')
+                    temp_src_file = tempfile.NamedTemporaryFile(dir=context.environment['temp_directory'], delete=False,
+                                                                suffix='.py')
                     temp_src_file.write(test_src)
                     temp_src_file.close()
-                    test_code_block = compile(test_src, temp_src_file.name, 'exec')
-                    exec test_code_block in global_ns, local_ns
-                    os.unlink(temp_src_file.name)
+                    try:
+                        test_code_block = compile(test_src, temp_src_file.name, 'exec')
+                        exec test_code_block in global_ns, local_ns
+                    finally:
+                        os.unlink(temp_src_file.name)
                 except KeyboardInterrupt:
                     raise
                 except:

--- a/fbtest.py
+++ b/fbtest.py
@@ -1011,7 +1011,14 @@ class TestVersion(object):
                 try:
                     sys.stdout = StringIO()
                     sys.stderr = StringIO()
-                    exec substitute_macros(self.test_script) in global_ns, local_ns
+                    # put Python code into temporary file to allow easy debugging
+                    test_src = substitute_macros(self.test_script)
+                    temp_src_file = tempfile.NamedTemporaryFile(dir=context.environment['temp_directory'], delete=False, suffix='.py')
+                    temp_src_file.write(test_src)
+                    temp_src_file.close()
+                    test_code_block = compile(test_src, temp_src_file.name, 'exec')
+                    exec test_code_block in global_ns, local_ns
+                    os.unlink(temp_src_file.name)
                 except KeyboardInterrupt:
                     raise
                 except:

--- a/fbtest.py
+++ b/fbtest.py
@@ -1015,6 +1015,8 @@ class TestVersion(object):
                     test_src = substitute_macros(self.test_script)
                     temp_src_file = tempfile.NamedTemporaryFile(dir=context.environment['temp_directory'], delete=False,
                                                                 suffix='.py')
+                    if isinstance(test_src, types.UnicodeType):
+                        test_src = test_src.encode('utf-8')
                     temp_src_file.write(test_src)
                     temp_src_file.close()
                     try:


### PR DESCRIPTION
Put python source into temporary file and compile it before exec.
It allows to step in into this file in pdb debugger or any GUI
debugger like PyCharm.